### PR TITLE
5 都道府県選択UIの作成

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -8,6 +8,9 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    nextjs: {
+      appDirectory: true,
+    },
   },
 };
 

--- a/app/_components/LabeledChoice.stories.tsx
+++ b/app/_components/LabeledChoice.stories.tsx
@@ -1,0 +1,80 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import LabeledChoice from "./LabeledChoice";
+import { expect, fn, Mock, userEvent, waitFor, within } from "@storybook/test";
+
+const meta = {
+  title: "Components/LabeledChoice",
+  component: LabeledChoice,
+} satisfies Meta<typeof LabeledChoice>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  args: {
+    label: "ラベル",
+    onChoose: fn(),
+  },
+  play: async ({ canvasElement, step, args }) => {
+    const canvas = within(canvasElement);
+
+    await step("初期状態", async () => {
+      await expect(canvas.getByText(args.label)).toBeInTheDocument();
+      await expect(canvas.getByRole("checkbox", { checked: false })).toBeInTheDocument();
+      await expect(args.onChoose).not.toHaveBeenCalled();
+    });
+
+    await step("1回目のクリック", async () => {
+      await userEvent.click(canvas.getByRole("checkbox"));
+      await waitFor(() => {
+        expect(args.onChoose).toBeCalledWith(true, args.label);
+      });
+      await expect(args.onChoose).toHaveBeenCalledTimes(1);
+      await expect(await canvas.findByRole("checkbox", { checked: true })).toBeInTheDocument();
+    });
+
+    await step("2回目のクリック", async () => {
+      await userEvent.click(canvas.getByRole("checkbox"));
+      await expect(args.onChoose).toBeCalledWith(false, args.label);
+      await waitFor(async () => {
+        await expect(args.onChoose).toBeCalledWith(true, args.label);
+      });
+      await expect(args.onChoose).toHaveBeenCalledTimes(2);
+      await expect(await canvas.findByRole("checkbox", { checked: false })).toBeInTheDocument();
+    });
+  },
+} satisfies Story;
+
+export const DefaultChecked = {
+  args: {
+    label: "最初からチェック済み",
+    defaultChosen: true,
+    onChoose: fn(),
+  },
+  play: async (context) => {
+    const { canvasElement, step, args } = context;
+    const canvas = within(canvasElement);
+
+    await step("初期状態", async () => {
+      await expect(canvas.getByText(args.label)).toBeInTheDocument();
+      await expect(canvas.getByRole("checkbox", { checked: true })).toBeInTheDocument();
+      await expect(args.onChoose).not.toHaveBeenCalled();
+    });
+
+    await step("1回目のクリック", async () => {
+      await userEvent.click(canvas.getByRole("checkbox"));
+      await waitFor(() => {
+        expect(args.onChoose).toBeCalledWith(false, args.label);
+      });
+      await expect(args.onChoose).toHaveBeenCalledTimes(1);
+      await expect(await canvas.findByRole("checkbox", { checked: false })).toBeInTheDocument();
+    });
+
+    await step("Default.play()の再利用", async (context) => {
+      // 実体が fn() であることが明白かつテストコードで影響度が低いため as を使用
+      (args.onChoose as Mock).mockClear();
+      await Default.play(context);
+    });
+  },
+} satisfies Story;

--- a/app/_components/LabeledChoice.tsx
+++ b/app/_components/LabeledChoice.tsx
@@ -1,0 +1,30 @@
+type Plops = {
+  /** 表示ラベルおよび {@link onChoose} に渡される識別子*/
+  label: string;
+  /** 選択状態の初期値 */
+  defaultChosen?: boolean;
+  /**
+   * 選択状態が変化した時のコールバック
+   * @param isChosen 選択状態か否か
+   * @param label 選択肢の表示名
+   */
+  onChoose?: (isChosen: boolean, label: string) => void;
+};
+
+/**
+ * チェックボックスとラベルのペア
+ */
+export default function LabeledChoice({ label, defaultChosen, onChoose }: Plops) {
+  return (
+    <label>
+      <input
+        type="checkbox"
+        defaultChecked={defaultChosen}
+        onChange={(ev) => {
+          onChoose?.(ev.target.checked, label);
+        }}
+      ></input>
+      <span>{label}</span>
+    </label>
+  );
+}

--- a/app/_components/MultiselectableChoices.stories.tsx
+++ b/app/_components/MultiselectableChoices.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import MultiselectableChoices from "./MultiselectableChoices";
+import { expect, fn, userEvent, waitFor, within } from "@storybook/test";
+
+const meta = {
+  title: "Components/MultiselectableChoices",
+  component: MultiselectableChoices,
+} satisfies Meta<typeof MultiselectableChoices>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+  args: {
+    legend: "複数選択UIタイトル",
+    options: [
+      { label: "炭水化物" },
+      { label: "脂質", defaultChosen: 3 },
+      { label: "タンパク質", defaultChosen: NaN },
+      { label: "ビタミン", defaultChosen: -Infinity },
+      { label: "ミネラル" },
+      { label: "タンパク質", defaultChosen: Infinity },
+    ],
+    onChoose: fn(),
+  },
+  play: async ({ canvasElement, step, args }) => {
+    const canvas = within(canvasElement);
+
+    await step("初期状態", async () => {
+      await expect(canvas.getByText(args.legend)).toBeInTheDocument();
+      await expect(args.onChoose).toHaveBeenCalledTimes(0);
+      await expect(canvas.getAllByRole("checkbox", { checked: true })).toHaveLength(2);
+      await expect(canvas.getAllByRole("checkbox", { checked: false })).toHaveLength(3);
+    });
+
+    await step("炭水化物を追加", async () => {
+      await userEvent.click(canvas.getByLabelText("炭水化物"));
+      await waitFor(() => expect(args.onChoose).toHaveBeenCalledTimes(1));
+      await expect(args.onChoose).toBeCalledWith(["ビタミン", "脂質", "炭水化物"]);
+      await expect(await canvas.findAllByRole("checkbox", { checked: true })).toHaveLength(3);
+      await expect(await canvas.findAllByRole("checkbox", { checked: false })).toHaveLength(2);
+    });
+
+    await step("脂質を削除", async () => {
+      await userEvent.click(canvas.getByLabelText("脂質"));
+      await waitFor(() => expect(args.onChoose).toHaveBeenCalledTimes(2));
+      await expect(args.onChoose).toBeCalledWith(["ビタミン", "炭水化物"]);
+      await expect(await canvas.findAllByRole("checkbox", { checked: true })).toHaveLength(2);
+      await expect(await canvas.findAllByRole("checkbox", { checked: false })).toHaveLength(3);
+    });
+  },
+} satisfies Story;

--- a/app/_components/MultiselectableChoices.tsx
+++ b/app/_components/MultiselectableChoices.tsx
@@ -1,0 +1,82 @@
+import LabeledChoice from "./LabeledChoice";
+import { useState } from "react";
+
+/** 選択肢 */
+type Option = {
+  /** 表示ラベルおよび {@link Plops.onChoose} に渡される識別子 */
+  label: string;
+  /** 初期の選択状態 falsy値なら未選択 そうでなければ小さな値から順に選択されていることにする */
+  defaultChosen?: number;
+};
+
+type Plops = {
+  /** 選択肢をひとまとめに表すラベル */
+  legend: string;
+  /** 表示する全ての選択肢 */
+  options: Option[];
+  /**
+   * 選択状態が変化した時のコールバック
+   * @param labels 選択された全てのラベル 先に選択されたものから順に並ぶ
+   */
+  onChoose?: (labels: readonly string[]) => void;
+};
+
+/**
+ * 複数選択可能な選択肢提供UI
+ *
+ * {@link options}のラベルに重複があった場合は最初の物を残し削除される
+ *
+ * 選択状態が変化した時は、{@link onChoose}で選択ラベルとその順が通知される
+ */
+export default function MultiselectableChoices({ legend, options, onChoose }: Plops) {
+  // 重複するlabelをもつOptionを削除
+  options = options.filter(
+    ({ label }, index, self) => self.findIndex((rhs) => label === rhs.label) === index
+  );
+
+  const [selections, setSelections] = useState<readonly string[]>(getSelections(options));
+
+  return (
+    <fieldset aria-multiselectable>
+      <legend>{legend}</legend>
+      {options.map(({ label, defaultChosen }) => (
+        <LabeledChoice
+          key={label}
+          label={label}
+          defaultChosen={Boolean(defaultChosen)}
+          onChoose={(isChosen, label) => {
+            const newSelections = updateSelections(isChosen, label, selections);
+            setSelections(() => newSelections);
+            onChoose?.(newSelections);
+          }}
+        />
+      ))}
+    </fieldset>
+  );
+}
+
+// defaultChosen が undefined でないユーザー定義型ガード用の型
+// Typescript 5.5 の型推論強化がリリースされれば不要なコード
+type NotUndefinedOption = {
+  label: string;
+  defaultChosen: number;
+};
+
+// 初期選択済みラベル配列を作成する
+function getSelections(options: Option[]): string[] {
+  return options
+    .filter((option): option is NotUndefinedOption => {
+      return Boolean(option.defaultChosen);
+    })
+    .sort((a, b) => a.defaultChosen - b.defaultChosen)
+    .map(({ label }) => label);
+}
+
+// isChosen が ture なら selections に追加、そうでなければ selections の該当 label 削除を行う
+function updateSelections(
+  isChosen: boolean,
+  label: string,
+  selections: readonly string[]
+): string[] {
+  return isChosen ? [...selections, label] : selections.filter((selection) => selection !== label);
+}

--- a/app/_test/storybook.test.tsx
+++ b/app/_test/storybook.test.tsx
@@ -1,0 +1,73 @@
+/// <reference types="vite/client" />
+
+/**
+ * Storybook の全ての Story をテストするスクリプト
+ * @see {@link https://zenn.dev/yumemi_inc/articles/run-all-stories-as-test-with-vitest-jsdom
+ *  Vitest(jsdom)でStorybookのStory全部テストする大作戦}
+ */
+
+import { composeStories, Meta, StoryFn } from "@storybook/react";
+import { render } from "@testing-library/react";
+import { describe, test } from "vitest";
+
+declare module "@storybook/types" {
+  interface Parameters {
+    vitest?: {
+      /**
+       * テストレベルを指定します。
+       * - `none`: Story をスキップします。（Storybook でのみ実行されます）
+       * - `smoke-only`: Story のレンダリングのみをテストします。
+       * - `interaction`: Story のレンダリングとインタラクションをテストします。
+       *
+       * @default "interaction"
+       */
+      testLevel?: "none" | "smoke-only" | "interaction" | undefined;
+    };
+  }
+}
+
+const stories = Promise.all(
+  Object.entries(
+    import.meta.glob<{
+      default: Meta;
+      [name: string]: StoryFn | Meta;
+    }>("../**/*.(stories|story).@(js|jsx|mjs|ts|tsx)", {
+      eager: true,
+    })
+  ).map(async ([path, exports]) => {
+    const composedStories = composeStories(exports);
+    return {
+      path: path.replace(/^\.\.\//, "app/"),
+      stories: Object.entries(composedStories).map(([name, Component]) => {
+        const runStory = async () => {
+          const testLevel = Component.parameters.vitest?.testLevel ?? "interaction";
+
+          if (testLevel === "none") {
+            return;
+          }
+
+          const screen = render(<Component />);
+
+          if (testLevel === "smoke-only") {
+            return;
+          }
+
+          await Component.play?.({ canvasElement: screen.container });
+        };
+
+        return {
+          name,
+          runStory,
+        };
+      }),
+    };
+  })
+);
+
+stories.then((stories) => {
+  describe.each(stories)("$path", ({ stories }) => {
+    test.each(stories)("$name", async ({ runStory }) => {
+      await runStory();
+    });
+  });
+});

--- a/app/page.stories.tsx
+++ b/app/page.stories.tsx
@@ -4,11 +4,6 @@ import Home from "./page";
 const meta = {
   title: "Home",
   component: Home,
-  parameters: {
-    nextjs: {
-      appDirectory: true,
-    },
-  },
 } as Meta<typeof Home>;
 
 export default meta;


### PR DESCRIPTION
#5 の各項目に対応し、人口推移を図示したい都道府県を選択(複数可)するための基礎となるUIコンポーネントを作成した。

都道府県一覧や人口推移データを外部から得る機能はまだ作成していない。

close #5

