### PR TITLE
テスト時もアットマークを用いたimportを可能にした #13

### DIFF
--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,5 +1,6 @@
 import { coverageConfigDefaults, defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import * as path from "node:path";
 
 export default defineConfig({
   plugins: [react()],
@@ -11,6 +12,9 @@ export default defineConfig({
       all: true,
       exclude: ["next.config.mjs", "app/layout.tsx", ...coverageConfigDefaults.exclude],
       reporter: ["text", "json-summary", "json", "html"],
+    },
+    alias: {
+      "@": path.resolve(__dirname, "./"),
     },
   },
 });


### PR DESCRIPTION
#13 の項目に対応し、テスト時のインポートエイリアスを設定した。

今はまだコンポーネントが全て `_components` の同階層にあるのでインポートパスの変更はしなかった。

close #13