### PR TITLE
都道府県選択機能を作成 #17

### DIFF
--- a/app/_actions/resas.ts
+++ b/app/_actions/resas.ts
@@ -50,8 +50,6 @@ const ApiKind = {
 
 type ApiKind = (typeof ApiKind)[keyof typeof ApiKind];
 
-type ErrorType = (typeof ErrorType)[keyof typeof ErrorType];
-
 const positiveIntSchema = z.number().positive().int();
 
 const prefecturesSchema = z.object({

--- a/app/_actions/resas.types.ts
+++ b/app/_actions/resas.types.ts
@@ -26,6 +26,9 @@ export const ErrorType = {
   JSONParseError: "JSON parse error.",
 } as const;
 
+/** RESAS に関連する Server Actions が返すエラーの種類 */
+export type ErrorType = (typeof ErrorType)[keyof typeof ErrorType];
+
 /** 人口構成データの構成種類 */
 export const CompositionType = {
   All: "総人口",

--- a/app/_components/MultiselectableChoices.tsx
+++ b/app/_components/MultiselectableChoices.tsx
@@ -2,7 +2,7 @@ import LabeledChoice from "./LabeledChoice";
 import { useState } from "react";
 
 /** 選択肢 */
-type Option = {
+export type Option = {
   /** 表示ラベル */
   label: string;
   /** {@link onChoose} に渡される値。 もし Falsy なら {@link label} で代用する */

--- a/app/_features/PrefecturesSelector.test.tsx
+++ b/app/_features/PrefecturesSelector.test.tsx
@@ -1,0 +1,46 @@
+import PrefecturesSelector from "./PrefecturesSelector";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ErrorType, Prefecture } from "@/app/_actions/resas.types";
+import * as resas from "@/app/_actions/resas";
+import * as r from "@totto2727/result";
+
+describe("PrefectureSelector", () => {
+  test("初期状態の確認", () => {
+    render(<PrefecturesSelector />);
+    expect(screen.getByText("都道府県を選択")).toBeInTheDocument();
+  });
+
+  test("都道府県一覧取得成功時の挙動確認", async () => {
+    const apiMock = vi.spyOn(resas, "getPrefectures");
+    apiMock.mockResolvedValue(r.succeed(dataset));
+    const fnMock = vi.fn();
+    render(<PrefecturesSelector onChoose={fnMock} />);
+    await userEvent.click(await screen.findByLabelText("青森県"));
+    expect(fnMock).toBeCalledWith([2]);
+    await userEvent.click(screen.getByLabelText("北海道"));
+    expect(fnMock).toBeCalledWith([2, 1]);
+    await userEvent.click(screen.getByLabelText("青森県"));
+    expect(fnMock).toBeCalledWith([1]);
+    apiMock.mockRestore();
+  });
+
+  test("エラー時にはその表示がある", async () => {
+    const mock = vi.spyOn(resas, "getPrefectures");
+    mock.mockResolvedValue(r.fail(ErrorType.ApiError));
+    render(<PrefecturesSelector />);
+    expect(await screen.findByText(ErrorType.ApiError)).toBeInTheDocument();
+    mock.mockRestore();
+  });
+});
+
+const dataset = [
+  {
+    prefCode: 1,
+    prefName: "北海道",
+  },
+  {
+    prefCode: 2,
+    prefName: "青森県",
+  },
+] satisfies Prefecture[];

--- a/app/_features/PrefecturesSelector.tsx
+++ b/app/_features/PrefecturesSelector.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import MultiselectableChoices, { Option } from "@/app/_components/MultiselectableChoices";
+import { useEffect, useState, useTransition } from "react";
+import { getPrefectures } from "@/app/_actions/resas";
+import { ErrorType } from "@/app/_actions/resas.types";
+import * as r from "@totto2727/result";
+
+type Props = {
+  /**
+   * 選択状態が変化した時のコールバック
+   * @param prefCodes 選択された全ての都道府県コード 先に選択されたものから順に並ぶ
+   */
+  onChoose?: (prefCodes: readonly number[]) => void;
+};
+
+/**
+ * 都道府県選択機能
+ */
+export default function PrefecturesSelector({ onChoose }: Props) {
+  const [isPending, startTransition] = useTransition();
+  const [error, setError] = useState<ErrorType | null>(null);
+  const [prefectures, setPrefectures] = useState<Option[]>([]);
+
+  useEffect(() => {
+    startTransition(async () => {
+      const result = await getPrefectures();
+      if (r.isSuccess(result)) {
+        setPrefectures(
+          result.value.map((v) => {
+            return { label: v.prefName, value: v.prefCode.toString() };
+          })
+        );
+      } else {
+        setError(result.cause);
+      }
+    });
+  }, []);
+  return (
+    <div>
+      {isPending ? (
+        <p>読み込み中…</p>
+      ) : error ? (
+        <p>{error}</p>
+      ) : (
+        <MultiselectableChoices
+          legend={"都道府県を選択"}
+          options={prefectures}
+          onChoose={(prefectures) => onChoose?.(prefectures.map((v) => Number.parseInt(v)))}
+        />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
#17 の項目に対応し、都道府県を自動で取得、表示する機能を作成した。

`Storybook` 上でのモジュールモックはまだ困難であると判断し、テストはストーリーではなく `testing-library` を用いて実装した。

close #17