### PR TITLE
PrefecturesSelector のコールバックAPIを変更 #21

### DIFF
--- a/app/_features/PrefecturesSelector.test.tsx
+++ b/app/_features/PrefecturesSelector.test.tsx
@@ -17,11 +17,11 @@ describe("PrefectureSelector", () => {
     const fnMock = vi.fn();
     render(<PrefecturesSelector onChoose={fnMock} />);
     await userEvent.click(await screen.findByLabelText("青森県"));
-    expect(fnMock).toBeCalledWith([2]);
+    expect(fnMock).toBeCalledWith([dataset[1]]);
     await userEvent.click(screen.getByLabelText("北海道"));
-    expect(fnMock).toBeCalledWith([2, 1]);
+    expect(fnMock).toBeCalledWith([dataset[1], dataset[0]]);
     await userEvent.click(screen.getByLabelText("青森県"));
-    expect(fnMock).toBeCalledWith([1]);
+    expect(fnMock).toBeCalledWith([dataset[0]]);
     apiMock.mockRestore();
   });
 

--- a/app/_features/PrefecturesSelector.tsx
+++ b/app/_features/PrefecturesSelector.tsx
@@ -3,15 +3,15 @@
 import MultiselectableChoices, { Option } from "@/app/_components/MultiselectableChoices";
 import { useEffect, useState, useTransition } from "react";
 import { getPrefectures } from "@/app/_actions/resas";
-import { ErrorType } from "@/app/_actions/resas.types";
+import { ErrorType, Prefecture } from "@/app/_actions/resas.types";
 import * as r from "@totto2727/result";
 
 type Props = {
   /**
    * 選択状態が変化した時のコールバック
-   * @param prefCodes 選択された全ての都道府県コード 先に選択されたものから順に並ぶ
+   * @param prefectures 選択された全ての都道府県 先に選択されたものから順に並ぶ
    */
-  onChoose?: (prefCodes: readonly number[]) => void;
+  onChoose?: (prefectures: readonly Prefecture[]) => void;
 };
 
 /**
@@ -28,7 +28,7 @@ export default function PrefecturesSelector({ onChoose }: Props) {
       if (r.isSuccess(result)) {
         setPrefectures(
           result.value.map((v) => {
-            return { label: v.prefName, value: v.prefCode.toString() };
+            return { label: v.prefName, value: `${v.prefCode}_${v.prefName}` };
           })
         );
       } else {
@@ -46,7 +46,14 @@ export default function PrefecturesSelector({ onChoose }: Props) {
         <MultiselectableChoices
           legend={"都道府県を選択"}
           options={prefectures}
-          onChoose={(prefectures) => onChoose?.(prefectures.map((v) => Number.parseInt(v)))}
+          onChoose={(prefectures) =>
+            onChoose?.(
+              prefectures.map((v) => {
+                const split = v.split("_");
+                return { prefCode: parseInt(split[0]), prefName: split[1] };
+              })
+            )
+          }
         />
       )}
     </div>


### PR DESCRIPTION
#21 の項目に対応し、 `PrefecturesSelector` のコールバック引数に都道府県コード、都道府県名を渡すようにした。

close #21